### PR TITLE
Exclude non-essentials files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+* text=auto
+
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/CHANGELOG.md export-ignore
+/ISSUE_TEMPLATE.md export-ignore
+/README.md export-ignore


### PR DESCRIPTION
This way the users of this package doesn't have to download files which aren't necessary for the package to function.

Happy Hacktoberfest!